### PR TITLE
Do not store apk index during install of build-base package

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -2,7 +2,7 @@ ARG  TAG=1.16-alpine
 FROM golang:${TAG}
 
 # Install base build packages
-RUN apk add build-base
+RUN apk --no-cache add build-base
 
 # Install delve
 RUN go install github.com/go-delve/delve/cmd/dlv@latest


### PR DESCRIPTION

- do not store/cache apk package index
