### PR TITLE
install devspace-restart-helper, image version updates, GH Actions flow update, 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 **
 !install_tooling.sh
+!devspace-restart-helper

--- a/.github/workflows/alpine.yaml
+++ b/.github/workflows/alpine.yaml
@@ -26,4 +26,35 @@ jobs:
           devspace build --var TAG=latest
           devspace build --var TAG=3
         working-directory: ./alpine
-
+      - name: Synk Docker scan for TAG=latest
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          TAG: "latest"
+        with:
+          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        env:
+          TAG: "latest"
+        with:
+          sarif_file: snyk.sarif
+          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
+      - name: Synk Docker scan for TAG=3
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          TAG: "3"
+        with:
+          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        env:
+          TAG: "3"
+        with:
+          sarif_file: snyk.sarif
+          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"

--- a/.github/workflows/alpine.yaml
+++ b/.github/workflows/alpine.yaml
@@ -8,54 +8,54 @@ on:
       - "alpine/**"
       - ".github/workflows/alpine.yaml"
       - "install_tooling.sh"
+  workflow_call:
+    secrets:
+      IMAGE_PREFIX:
+        description: "registry.com/loftsh in registry.com/loftsh/language:TAG"
+        required: true
 
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
   LANGUAGE: "alpine"
+  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+defaults:
+  run:
+    working-directory: alpine
 
 jobs:
   alpine:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tag: edge
+            target_tag: edge
+          - tag: latest
+            target_tag: latest
+          - tag: 3.14
+            target_tag: 3.14
+          - tag: 3.13
+            target_tag: 3.13
+          - tag: 3.12
+            target_tag: 3.12
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - name: Install DevSpace
-        uses: loft-sh/setup-devspace@main
-      - run: |
-          devspace build --var TAG=latest
-          devspace build --var TAG=3
-        working-directory: ./alpine
-      - name: Synk Docker scan for TAG=latest
+      - uses: loft-sh/setup-devspace@main
+      - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
+      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
         continue-on-error: true
         uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          TAG: "latest"
         with:
-          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
+          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
           args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v1
-        env:
-          TAG: "latest"
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
-      - name: Synk Docker scan for TAG=3
         continue-on-error: true
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          TAG: "3"
-        with:
-          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v1
-        env:
-          TAG: "3"
         with:
           sarif_file: snyk.sarif
-          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
+          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"

--- a/.github/workflows/alpine.yaml
+++ b/.github/workflows/alpine.yaml
@@ -10,7 +10,7 @@ on:
       - "install_tooling.sh"
 
 env:
-  IMAGE_PREFIX: loftsh
+  IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
 
 jobs:
   alpine:
@@ -20,7 +20,8 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - run: chmod +x install_tooling.sh && sudo ./install_tooling.sh
+      - name: Install DevSpace
+        uses: loft-sh/setup-devspace@main
       - run: |
           devspace build --var TAG=latest
           devspace build --var TAG=3

--- a/.github/workflows/alpine.yaml
+++ b/.github/workflows/alpine.yaml
@@ -11,6 +11,7 @@ on:
 
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
+  LANGUAGE: "alpine"
 
 jobs:
   alpine:

--- a/.github/workflows/alpine.yaml
+++ b/.github/workflows/alpine.yaml
@@ -17,7 +17,6 @@ on:
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
   LANGUAGE: "alpine"
-  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
 defaults:
   run:
@@ -30,8 +29,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - tag: edge
-            target_tag: edge
           - tag: latest
             target_tag: latest
           - tag: 3.14
@@ -47,15 +44,3 @@ jobs:
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - uses: loft-sh/setup-devspace@main
       - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
-      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
-        continue-on-error: true
-        uses: snyk/actions/docker@master
-        with:
-          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"

--- a/.github/workflows/alpine.yaml
+++ b/.github/workflows/alpine.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   alpine:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -8,88 +8,56 @@ on:
       - "dotnet/**"
       - ".github/workflows/dotnet.yaml"
       - "install_tooling.sh"
+  workflow_call:
+    secrets:
+      IMAGE_PREFIX:
+        description: "registry.com/loftsh in registry.com/loftsh/language:TAG"
+        required: true
 
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
   LANGUAGE: "dotnet"
+  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+defaults:
+  run:
+    working-directory: dotnet
 
 jobs:
   dotnet:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tag: 6.0-alpine
+            target_tag: latest
+          - tag: 6.0-alpine
+            target_tag: 6.0
+          - tag: 6.0-alpine
+            target_tag: 6.0-alpine
+          - tag: 5.0-bullseye-slim
+            target_tag: 5.0
+          - tag: 5.0-bullseye-slim
+            target_tag: 5.0-bullseye-slim
+          - tag: 3.1
+            target_tag: 3.1
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - name: Install DevSpace
-        uses: loft-sh/setup-devspace@main
-      - run: |
-          devspace build --var TAG=latest
-          devspace build --var TAG=6.0
-          devspace build --var TAG=5.0
-          devspace build --var TAG=3.1
-        working-directory: ./dotnet
-      - name: Synk Docker scan for TAG=latest
+      - uses: loft-sh/setup-devspace@main
+      - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
+      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
         continue-on-error: true
         uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          TAG: "latest"
         with:
-          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
+          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
           args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v1
-        env:
-          TAG: "latest"
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
-      - name: Synk Docker scan for TAG=6.0
         continue-on-error: true
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          TAG: "6.0"
-        with:
-          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v1
-        env:
-          TAG: "6.0"
         with:
           sarif_file: snyk.sarif
-          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
-      - name: Synk Docker scan for TAG=5.0
-        continue-on-error: true
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          TAG: "5.0"
-        with:
-          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v1
-        env:
-          TAG: "5.0"
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
-      - name: Synk Docker scan for TAG=3.1
-        continue-on-error: true
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          TAG: "3.1"
-        with:
-          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v1
-        env:
-          TAG: "3.1"
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
+          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -24,8 +24,8 @@ jobs:
         uses: loft-sh/setup-devspace@main
       - run: |
           devspace build --var TAG=latest
-          devspace build --var TAG=6.0-alpine
-          devspace build --var TAG=5.0-alpine
-          devspace build --var TAG=3.1-alpine
+          devspace build --var TAG=6.0
+          devspace build --var TAG=5.0
+          devspace build --var TAG=3.1
         working-directory: ./dotnet
 

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -10,7 +10,7 @@ on:
       - "install_tooling.sh"
 
 env:
-  IMAGE_PREFIX: loftsh
+  IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
 
 jobs:
   dotnet:
@@ -20,7 +20,8 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - run: chmod +x install_tooling.sh && sudo ./install_tooling.sh
+      - name: Install DevSpace
+        uses: loft-sh/setup-devspace@main
       - run: |
           devspace build --var TAG=latest
           devspace build --var TAG=6.0-alpine

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -11,6 +11,7 @@ on:
 
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
+  LANGUAGE: "dotnet"
 
 jobs:
   dotnet:
@@ -28,4 +29,67 @@ jobs:
           devspace build --var TAG=5.0
           devspace build --var TAG=3.1
         working-directory: ./dotnet
-
+      - name: Synk Docker scan for TAG=latest
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          TAG: "latest"
+        with:
+          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        env:
+          TAG: "latest"
+        with:
+          sarif_file: snyk.sarif
+          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
+      - name: Synk Docker scan for TAG=6.0
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          TAG: "6.0"
+        with:
+          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        env:
+          TAG: "6.0"
+        with:
+          sarif_file: snyk.sarif
+          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
+      - name: Synk Docker scan for TAG=5.0
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          TAG: "5.0"
+        with:
+          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        env:
+          TAG: "5.0"
+        with:
+          sarif_file: snyk.sarif
+          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
+      - name: Synk Docker scan for TAG=3.1
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          TAG: "3.1"
+        with:
+          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        env:
+          TAG: "3.1"
+        with:
+          sarif_file: snyk.sarif
+          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -17,7 +17,6 @@ on:
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
   LANGUAGE: "dotnet"
-  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
 defaults:
   run:
@@ -33,15 +32,10 @@ jobs:
           - tag: 6.0-alpine
             target_tag: latest
           - tag: 6.0-alpine
-            target_tag: 6.0
-          - tag: 6.0-alpine
             target_tag: 6.0-alpine
           - tag: 5.0-bullseye-slim
-            target_tag: 5.0
-          - tag: 5.0-bullseye-slim
             target_tag: 5.0-bullseye-slim
-          - tag: 3.1
-            target_tag: 3.1
+
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
@@ -49,15 +43,3 @@ jobs:
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - uses: loft-sh/setup-devspace@main
       - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
-      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
-        continue-on-error: true
-        uses: snyk/actions/docker@master
-        with:
-          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   dotnet:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
@@ -23,7 +23,8 @@ jobs:
       - run: chmod +x install_tooling.sh && sudo ./install_tooling.sh
       - run: |
           devspace build --var TAG=latest
-          devspace build --var TAG=5.0
-          devspace build --var TAG=3.1
+          devspace build --var TAG=6.0-alpine
+          devspace build --var TAG=5.0-alpine
+          devspace build --var TAG=3.1-alpine
         working-directory: ./dotnet
 

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -12,67 +12,31 @@ on:
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
   LANGUAGE: "go"
+  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
 jobs:
   go:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        tag: [latest, 1.17-alpine, 1.16-alpine]
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - name: Install DevSpace
-        uses: loft-sh/setup-devspace@main
-      - run: |
-          devspace build --var TAG=latest
-          devspace build --var TAG=1.17-alpine
-          devspace build --var TAG=1.16-alpine
+      - uses: loft-sh/setup-devspace@main
+      - run: devspace build --var TAG=${{ matrix.tag }}
         working-directory: ./go
-      - name: Synk Docker scan for TAG=latest
+      - name: Synk Docker scan for TAG=${{ matrix.tag }}
         continue-on-error: true
         uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          TAG: "latest"
         with:
-          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
+          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.tag }}
           args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v1
-        env:
-          TAG: "latest"
         with:
           sarif_file: snyk.sarif
-          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
-      - name: Synk Docker scan for TAG=1.17-alpine
-        continue-on-error: true
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          TAG: "1.17-alpine"
-        with:
-          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v1
-        env:
-          TAG: "1.17-alpine"
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
-      - name: Synk Docker scan for TAG=1.16-alpine
-        continue-on-error: true
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          TAG: "1.16-alpine"
-        with:
-          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v1
-        env:
-          TAG: "1.16-alpine"
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
+          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.tag }}"

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -11,7 +11,7 @@ on:
   workflow_call:
     secrets:
       IMAGE_PREFIX:
-        description: "loftsh in loftsh/language:TAG"
+        description: "registry.com/loftsh in registry.com/loftsh/language:TAG"
         required: true
 
 env:
@@ -21,7 +21,7 @@ env:
 
 defaults:
   run:
-    working-directory: ${{ env.LANGUAGE }}
+    working-directory: go
 
 jobs:
   go:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -17,7 +17,6 @@ on:
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
   LANGUAGE: "go"
-  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
 defaults:
   run:
@@ -30,8 +29,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - tag: 1.18-rc-alpine
-            target_tag: 1.18-rc-alpine
           - tag: 1.17-alpine
             target_tag: latest
           - tag: 1.17-alpine
@@ -45,15 +42,3 @@ jobs:
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - uses: loft-sh/setup-devspace@main
       - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
-      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
-        continue-on-error: true
-        uses: snyk/actions/docker@master
-        with:
-          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -20,7 +20,8 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - run: chmod +x install_tooling.sh && sudo ./install_tooling.sh
+      - name: Install DevSpace
+        uses: loft-sh/setup-devspace@main
       - run: |
           devspace build --var TAG=latest
           devspace build --var TAG=1.17-alpine

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -11,6 +11,7 @@ on:
 
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
+  LANGUAGE: "go"
 
 jobs:
   go:
@@ -32,34 +33,15 @@ jobs:
         uses: snyk/actions/docker@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          TAG: "latest"
         with:
-          image: ${{ secrets.IMAGE_PREFIX }}/go:latest
-          args: --file=go/Dockerfile
+          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: snyk.sarif
-      - name: Synk Docker scan for TAG=1.17-alpine
-        continue-on-error: true
-        uses: snyk/actions/docker@master
         env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: ${{ secrets.IMAGE_PREFIX }}/go:1.17-alpine
-          args: --file=go/Dockerfile
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v1
+          TAG: "latest"
         with:
           sarif_file: snyk.sarif
-      - name: Synk Docker scan for TAG=1.16-alpine
-        continue-on-error: true
-        uses: snyk/actions/docker@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: ${{ secrets.IMAGE_PREFIX }}/go:1.16-alpine
-          args: --file=go/Dockerfile
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: snyk.sarif
+          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
+

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -27,4 +27,3 @@ jobs:
           devspace build --var TAG=1.17-alpine
           devspace build --var TAG=1.16-alpine
         working-directory: ./go
-

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -35,6 +35,10 @@ jobs:
         with:
           image: ${{ secrets.IMAGE_PREFIX }}/go:latest
           args: --file=go/Dockerfile
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: snyk.sarif
       - name: Synk Docker scan for TAG=1.17-alpine
         continue-on-error: true
         uses: snyk/actions/docker@master
@@ -43,6 +47,10 @@ jobs:
         with:
           image: ${{ secrets.IMAGE_PREFIX }}/go:1.17-alpine
           args: --file=go/Dockerfile
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: snyk.sarif
       - name: Synk Docker scan for TAG=1.16-alpine
         continue-on-error: true
         uses: snyk/actions/docker@master

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   go:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -8,6 +8,15 @@ on:
       - "go/**"
       - ".github/workflows/go.yaml"
       - "install_tooling.sh"
+  workflow_call:
+    secrets:
+      IMAGE_PREFIX:
+        description: "loftsh in loftsh/language:TAG"
+        required: true
+
+defaults:
+  run:
+    working-directory: ${{ env.LANGUAGE }}
 
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
@@ -18,25 +27,33 @@ jobs:
   go:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        tag: [latest, 1.17-alpine, 1.16-alpine]
+        include:
+          - tag: 1.18-rc-alpine
+            target_tag: 1.18-rc-alpine
+          - tag: 1.17-alpine
+            target_tag: latest
+          - tag: 1.17-alpine
+            target_tag: 1.17-alpine
+          - tag: 1.16-alpine
+            target_tag: 1.16-alpine
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - uses: loft-sh/setup-devspace@main
-      - run: devspace build --var TAG=${{ matrix.tag }}
-        working-directory: ./${{ env.LANGUAGE }}
-      - name: Synk Docker scan for TAG=${{ matrix.tag }}
+      - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
+      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
         continue-on-error: true
         uses: snyk/actions/docker@master
         with:
-          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.tag }}
+          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
           args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
       - name: Upload result to GitHub Code Scanning
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@v1
         with:
           sarif_file: snyk.sarif
-          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.tag }}"
+          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -28,7 +28,7 @@ jobs:
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - uses: loft-sh/setup-devspace@main
       - run: devspace build --var TAG=${{ matrix.tag }}
-        working-directory: ./go
+        working-directory: ./${{ env.LANGUAGE }}
       - name: Synk Docker scan for TAG=${{ matrix.tag }}
         continue-on-error: true
         uses: snyk/actions/docker@master

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -10,7 +10,7 @@ on:
       - "install_tooling.sh"
 
 env:
-  IMAGE_PREFIX: loftsh
+  IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
 
 jobs:
   go:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -14,14 +14,14 @@ on:
         description: "loftsh in loftsh/language:TAG"
         required: true
 
-defaults:
-  run:
-    working-directory: ${{ env.LANGUAGE }}
-
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
   LANGUAGE: "go"
   SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+defaults:
+  run:
+    working-directory: ${{ env.LANGUAGE }}
 
 jobs:
   go:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -44,4 +44,35 @@ jobs:
         with:
           sarif_file: snyk.sarif
           category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
-
+      - name: Synk Docker scan for TAG=1.17-alpine
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          TAG: "1.17-alpine"
+        with:
+          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        env:
+          TAG: "1.17-alpine"
+        with:
+          sarif_file: snyk.sarif
+          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"
+      - name: Synk Docker scan for TAG=1.16-alpine
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          TAG: "1.16-alpine"
+        with:
+          image: ${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        env:
+          TAG: "1.16-alpine"
+        with:
+          sarif_file: snyk.sarif
+          category: "${{ secrets.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ env.TAG }}"

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -27,3 +27,31 @@ jobs:
           devspace build --var TAG=1.17-alpine
           devspace build --var TAG=1.16-alpine
         working-directory: ./go
+      - name: Synk Docker scan for TAG=latest
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: ${{ secrets.IMAGE_PREFIX }}/go:latest
+          args: --file=go/Dockerfile
+      - name: Synk Docker scan for TAG=1.17-alpine
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: ${{ secrets.IMAGE_PREFIX }}/go:1.17-alpine
+          args: --file=go/Dockerfile
+      - name: Synk Docker scan for TAG=1.16-alpine
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: ${{ secrets.IMAGE_PREFIX }}/go:1.16-alpine
+          args: --file=go/Dockerfile
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: snyk.sarif

--- a/.github/workflows/java-gradle.yaml
+++ b/.github/workflows/java-gradle.yaml
@@ -17,7 +17,6 @@ on:
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
   LANGUAGE: "java-gradle"
-  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
 defaults:
   run:
@@ -47,15 +46,3 @@ jobs:
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - uses: loft-sh/setup-devspace@main
       - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
-      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
-        continue-on-error: true
-        uses: snyk/actions/docker@master
-        with:
-          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"

--- a/.github/workflows/java-gradle.yaml
+++ b/.github/workflows/java-gradle.yaml
@@ -8,25 +8,58 @@ on:
       - "java-gradle/**"
       - ".github/workflows/java-gradle.yaml"
       - "install_tooling.sh"
+  workflow_call:
+    secrets:
+      IMAGE_PREFIX:
+        description: "registry.com/loftsh in registry.com/loftsh/language:TAG"
+        required: true
 
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
+  LANGUAGE: "java-gradle"
+  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+defaults:
+  run:
+    working-directory: java-gradle
 
 jobs:
   java-gradle:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tag: 7.3-jdk17-alpine
+            target_tag: latest
+          - tag: 7.3-jdk17-alpine
+            target_tag: 7.3-jdk17-alpine
+          - tag: 7.3-jdk11-alpine
+            target_tag: 7.3-jdk11-alpine
+          - tag: 7-jdk17-alpine
+            target_tag: 7-jdk17-alpine
+          - tag: 7-jdk11-alpine
+            target_tag: 7-jdk11-alpine
+          - tag: 6-jdk17-alpine
+            target_tag: 6-jdk17-alpine
+          - tag: 6-jdk11-alpine
+            target_tag: 6-jdk11-alpine
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - name: Install DevSpace
-        uses: loft-sh/setup-devspace@main
-      - run: |
-          devspace build --var TAG=latest
-          devspace build --var TAG=7-jdk11
-          devspace build --var TAG=7-jdk17
-          devspace build --var TAG=6-jdk11
-          devspace build --var TAG=6-jdk17
-        working-directory: ./java-gradle
-
+      - uses: loft-sh/setup-devspace@main
+      - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
+      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        with:
+          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
+      - name: Upload result to GitHub Code Scanning
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: snyk.sarif
+          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"

--- a/.github/workflows/java-gradle.yaml
+++ b/.github/workflows/java-gradle.yaml
@@ -10,7 +10,7 @@ on:
       - "install_tooling.sh"
 
 env:
-  IMAGE_PREFIX: loftsh
+  IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
 
 jobs:
   java-gradle:
@@ -20,7 +20,8 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - run: chmod +x install_tooling.sh && sudo ./install_tooling.sh
+      - name: Install DevSpace
+        uses: loft-sh/setup-devspace@main
       - run: |
           devspace build --var TAG=latest
           devspace build --var TAG=7-jdk11-alpine

--- a/.github/workflows/java-gradle.yaml
+++ b/.github/workflows/java-gradle.yaml
@@ -24,9 +24,9 @@ jobs:
         uses: loft-sh/setup-devspace@main
       - run: |
           devspace build --var TAG=latest
-          devspace build --var TAG=7-jdk11-alpine
-          devspace build --var TAG=7-jdk17-alpine
-          devspace build --var TAG=6-jdk11-alpine
-          devspace build --var TAG=6-jdk17-alpine
+          devspace build --var TAG=7-jdk11
+          devspace build --var TAG=7-jdk17
+          devspace build --var TAG=6-jdk11
+          devspace build --var TAG=6-jdk17
         working-directory: ./java-gradle
 

--- a/.github/workflows/java-gradle.yaml
+++ b/.github/workflows/java-gradle.yaml
@@ -30,20 +30,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - tag: 7.3-jdk17-alpine
+          - tag: latest
             target_tag: latest
-          - tag: 7.3-jdk17-alpine
-            target_tag: 7.3-jdk17-alpine
-          - tag: 7.3-jdk11-alpine
-            target_tag: 7.3-jdk11-alpine
-          - tag: 7-jdk17-alpine
-            target_tag: 7-jdk17-alpine
-          - tag: 7-jdk11-alpine
-            target_tag: 7-jdk11-alpine
-          - tag: 6-jdk17-alpine
-            target_tag: 6-jdk17-alpine
-          - tag: 6-jdk11-alpine
-            target_tag: 6-jdk11-alpine
+          - tag: 7-jdk17
+            target_tag: 7-jdk17
+          - tag: 7-jdk11
+            target_tag: 7-jdk11
+          - tag: 6-jdk17
+            target_tag: 6-jdk17
+          - tag: 6-jdk11
+            target_tag: 6-jdk11
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/java-gradle.yaml
+++ b/.github/workflows/java-gradle.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   java-gradle:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
@@ -23,7 +23,9 @@ jobs:
       - run: chmod +x install_tooling.sh && sudo ./install_tooling.sh
       - run: |
           devspace build --var TAG=latest
-          devspace build --var TAG=7.0-jdk11
-          devspace build --var TAG=7.0-jdk8
+          devspace build --var TAG=7-jdk11-alpine
+          devspace build --var TAG=7-jdk17-alpine
+          devspace build --var TAG=6-jdk11-alpine
+          devspace build --var TAG=6-jdk17-alpine
         working-directory: ./java-gradle
 

--- a/.github/workflows/java-maven.yaml
+++ b/.github/workflows/java-maven.yaml
@@ -10,7 +10,7 @@ on:
       - "install_tooling.sh"
 
 env:
-  IMAGE_PREFIX: loftsh
+  IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
 
 jobs:
   java-maven:
@@ -20,7 +20,8 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - run: chmod +x install_tooling.sh && sudo ./install_tooling.sh
+      - name: Install DevSpace
+        uses: loft-sh/setup-devspace@main
       - run: |
           devspace build --var TAG=3-jdk-11 --var TARGET_TAG=latest
           devspace build --var TAG=3-jdk-11 --var TARGET_TAG=3-jdk-11

--- a/.github/workflows/java-maven.yaml
+++ b/.github/workflows/java-maven.yaml
@@ -38,8 +38,6 @@ jobs:
             target_tag: 3-openjdk-11-slim
           - tag: 3-openjdk-8-slim
             target_tag: 3-openjdk-8-slim
-          - tag: 3-ibmjava-8
-            target_tag: 3-ibmjava-8
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/java-maven.yaml
+++ b/.github/workflows/java-maven.yaml
@@ -8,23 +8,59 @@ on:
       - "java-maven/**"
       - ".github/workflows/java-maven.yaml"
       - "install_tooling.sh"
+  workflow_call:
+    secrets:
+      IMAGE_PREFIX:
+        description: "registry.com/loftsh in registry.com/loftsh/language:TAG"
+        required: true
 
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
+  LANGUAGE: "java-maven"
+  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+defaults:
+  run:
+    working-directory: java-maven
 
 jobs:
   java-maven:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tag: 3-openjdk-17-slim
+            target_tag: latest
+          - tag: 3-openjdk-17-slim
+            target_tag: 3-openjdk-17-slim
+          - tag: 3-openjdk-11-slim
+            target_tag: 3-openjdk-11-slim
+          - tag: 3-openjdk-8-slim
+            target_tag: 3-openjdk-8-slim
+          - tag: 3-ibmjava-alpine
+            target_tag: 3-ibmjava-alpine
+          - tag: 3-ibmjava-8-alpine
+            target_tag: 3-ibmjava-8-alpine
+
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - name: Install DevSpace
-        uses: loft-sh/setup-devspace@main
-      - run: |
-          devspace build --var TAG=3-jdk-11 --var TARGET_TAG=latest
-          devspace build --var TAG=3-jdk-11 --var TARGET_TAG=3-jdk-11
-          devspace build --var TAG=3-jdk-8 --var TARGET_TAG=3-jdk-8
-        working-directory: ./java-maven
+      - uses: loft-sh/setup-devspace@main
+      - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
+      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        with:
+          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
+      - name: Upload result to GitHub Code Scanning
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: snyk.sarif
+          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"
+
 

--- a/.github/workflows/java-maven.yaml
+++ b/.github/workflows/java-maven.yaml
@@ -38,10 +38,8 @@ jobs:
             target_tag: 3-openjdk-11-slim
           - tag: 3-openjdk-8-slim
             target_tag: 3-openjdk-8-slim
-          - tag: 3-ibmjava-alpine
-            target_tag: 3-ibmjava-alpine
-          - tag: 3-ibmjava-8-alpine
-            target_tag: 3-ibmjava-8-alpine
+          - tag: 3-ibmjava-8
+            target_tag: 3-ibmjava-8
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/java-maven.yaml
+++ b/.github/workflows/java-maven.yaml
@@ -17,7 +17,6 @@ on:
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
   LANGUAGE: "java-maven"
-  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
 defaults:
   run:
@@ -46,17 +45,5 @@ jobs:
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - uses: loft-sh/setup-devspace@main
       - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
-      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
-        continue-on-error: true
-        uses: snyk/actions/docker@master
-        with:
-          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"
 
 

--- a/.github/workflows/java-maven.yaml
+++ b/.github/workflows/java-maven.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   java-maven:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/javascript.yaml
+++ b/.github/workflows/javascript.yaml
@@ -8,25 +8,60 @@ on:
       - "javascript/**"
       - ".github/workflows/javascript.yaml"
       - "install_tooling.sh"
+  workflow_call:
+    secrets:
+      IMAGE_PREFIX:
+        description: "registry.com/loftsh in registry.com/loftsh/language:TAG"
+        required: true
 
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
+  LANGUAGE: "javascript"
+  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+defaults:
+  run:
+    working-directory: javascript
 
 jobs:
   javascript:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tag: 17-alpine
+            target_tag: latest
+          - tag: 17-alpine
+            target_tag: 17-alpine
+          - tag: lts-alpine
+            target_tag: lts-alpine
+          - tag: lts-alpine
+            target_tag: lts
+          - tag: 16-alpine
+            target_tag: 16-alpine
+          - tag: 14-alpine
+            target_tag: 14-alpine
+          - tag: 12-alpine
+            target_tag: 12-alpine
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - name: Install DevSpace
-        uses: loft-sh/setup-devspace@main
-      - run: |
-          devspace build --var TAG=latest
-          devspace build --var TAG=15-alpine
-          devspace build --var TAG=14-alpine
-          devspace build --var TAG=12-alpine
-          devspace build --var TAG=10-alpine
-        working-directory: ./javascript
+      - uses: loft-sh/setup-devspace@main
+      - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
+      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        with:
+          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
+      - name: Upload result to GitHub Code Scanning
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: snyk.sarif
+          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"
+
 

--- a/.github/workflows/javascript.yaml
+++ b/.github/workflows/javascript.yaml
@@ -10,7 +10,7 @@ on:
       - "install_tooling.sh"
 
 env:
-  IMAGE_PREFIX: loftsh
+  IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
 
 jobs:
   javascript:
@@ -20,7 +20,8 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - run: chmod +x install_tooling.sh && sudo ./install_tooling.sh
+      - name: Install DevSpace
+        uses: loft-sh/setup-devspace@main
       - run: |
           devspace build --var TAG=latest
           devspace build --var TAG=15-alpine

--- a/.github/workflows/javascript.yaml
+++ b/.github/workflows/javascript.yaml
@@ -17,7 +17,6 @@ on:
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
   LANGUAGE: "javascript"
-  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
 defaults:
   run:
@@ -36,14 +35,9 @@ jobs:
             target_tag: 17-alpine
           - tag: lts-alpine
             target_tag: lts-alpine
-          - tag: lts-alpine
-            target_tag: lts
           - tag: 16-alpine
             target_tag: 16-alpine
-          - tag: 14-alpine
-            target_tag: 14-alpine
-          - tag: 12-alpine
-            target_tag: 12-alpine
+
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
@@ -51,17 +45,3 @@ jobs:
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - uses: loft-sh/setup-devspace@main
       - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
-      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
-        continue-on-error: true
-        uses: snyk/actions/docker@master
-        with:
-          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"
-
-

--- a/.github/workflows/javascript.yaml
+++ b/.github/workflows/javascript.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   javascript:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -17,7 +17,6 @@ on:
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
   LANGUAGE: "php"
-  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
 defaults:
   run:
@@ -34,20 +33,16 @@ jobs:
             target_tag: latest
           - tag: 8-apache-bullseye
             target_tag: latest-apache
-          - tag: 8-apache-bullseye
-            target_tag: apache
           - tag: 8.1-apache-bullseye
             target_tag: 8.1-apache-bullseye
           - tag: 8.0-apache-bullseye
             target_tag: 8.0-apache-bullseye
           - tag: 7-apache-bullseye
             target_tag: 7-apache-bullseye
-          - tag: 5-apache
-            target_tag: 5-apache
           - tag: 8-fpm
             target_tag: latest-fpm 
           - tag: 8-fpm
-            target_tag: fpm
+            target_tag: 8-fpm
           - tag: 7-fpm
             target_tag: 7-fpm
     steps:
@@ -57,16 +52,4 @@ jobs:
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - uses: loft-sh/setup-devspace@main
       - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
-      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
-        continue-on-error: true
-        uses: snyk/actions/docker@master
-        with:
-          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"
 

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   php:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -10,7 +10,7 @@ on:
       - "install_tooling.sh"
 
 env:
-  IMAGE_PREFIX: loftsh
+  IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
 
 jobs:
   php:
@@ -20,7 +20,8 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - run: chmod +x install_tooling.sh && sudo ./install_tooling.sh
+      - name: Install DevSpace
+        uses: loft-sh/setup-devspace@main
       - run: |
           devspace build --var TAG=8.0-apache --var TARGET_TAG=latest
           devspace build --var TAG=8.0-apache --var TARGET_TAG=8.0-apache

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -8,25 +8,65 @@ on:
       - "php/**"
       - ".github/workflows/php.yaml"
       - "install_tooling.sh"
+  workflow_call:
+    secrets:
+      IMAGE_PREFIX:
+        description: "registry.com/loftsh in registry.com/loftsh/language:TAG"
+        required: true
 
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
+  LANGUAGE: "php"
+  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+defaults:
+  run:
+    working-directory: php
 
 jobs:
   php:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tag: 8-apache-bullseye
+            target_tag: latest
+          - tag: 8-apache-bullseye
+            target_tag: latest-apache
+          - tag: 8-apache-bullseye
+            target_tag: apache
+          - tag: 8.1-apache-bullseye
+            target_tag: 8.1-apache-bullseye
+          - tag: 8.0-apache-bullseye
+            target_tag: 8.0-apache-bullseye
+          - tag: 7-apache-bullseye
+            target_tag: 7-apache-bullseye
+          - tag: 5-apache
+            target_tag: 5-apache
+          - tag: 8-fpm
+            target_tag: latest-fpm 
+          - tag: 8-fpm
+            target_tag: fpm
+          - tag: 7-fpm
+            target_tag: 7-fpm
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - name: Install DevSpace
-        uses: loft-sh/setup-devspace@main
-      - run: |
-          devspace build --var TAG=8.0-apache --var TARGET_TAG=latest
-          devspace build --var TAG=8.0-apache --var TARGET_TAG=8.0-apache
-          devspace build --var TAG=8.0-fpm --var TARGET_TAG=8.0-fpm
-          devspace build --var TAG=7.4-apache --var TARGET_TAG=7.4-apache
-          devspace build --var TAG=7.4-fpm --var TARGET_TAG=7.4-fpm
-        working-directory: ./php
+      - uses: loft-sh/setup-devspace@main
+      - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
+      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        with:
+          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
+      - name: Upload result to GitHub Code Scanning
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: snyk.sarif
+          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"
 

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -8,24 +8,60 @@ on:
       - "python/**"
       - ".github/workflows/python.yaml"
       - "install_tooling.sh"
+  workflow_call:
+    secrets:
+      IMAGE_PREFIX:
+        description: "registry.com/loftsh in registry.com/loftsh/language:TAG"
+        required: true
 
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
+  LANGUAGE: "python"
+  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+defaults:
+  run:
+    working-directory: python
 
 jobs:
   python:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tag: 3-alpine
+            target_tag: latest
+          - tag: 3-alpine
+            target_tag: 3-alpine
+          - tag: 3.11-rc-alpine
+            target_tag: 3.11-rc-alpine
+          - tag: 3.10-alpine
+            target_tag: 3.10-alpine
+          - tag: 3.9-alpine
+            target_tag: 3.9-alpine
+          - tag: 3.8-alpine
+            target_tag: 3.8-alpine
+          - tag: 3.7-alpine
+            target_tag: 3.7-alpine
+          - tag: 3.6-alpine
+            target_tag: 3.6-alpine
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - name: Install DevSpace
-        uses: loft-sh/setup-devspace@main
-      - run: |
-          devspace build --var TAG=latest
-          devspace build --var TAG=3.9-alpine
-          devspace build --var TAG=3.8-alpine
-          devspace build --var TAG=3.7-alpine
-        working-directory: ./python
-
+      - uses: loft-sh/setup-devspace@main
+      - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
+      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        with:
+          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
+      - name: Upload result to GitHub Code Scanning
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: snyk.sarif
+          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -17,7 +17,6 @@ on:
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
   LANGUAGE: "python"
-  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
 defaults:
   run:
@@ -34,18 +33,13 @@ jobs:
             target_tag: latest
           - tag: 3-alpine
             target_tag: 3-alpine
-          - tag: 3.11-rc-alpine
-            target_tag: 3.11-rc-alpine
           - tag: 3.10-alpine
             target_tag: 3.10-alpine
           - tag: 3.9-alpine
             target_tag: 3.9-alpine
           - tag: 3.8-alpine
             target_tag: 3.8-alpine
-          - tag: 3.7-alpine
-            target_tag: 3.7-alpine
-          - tag: 3.6-alpine
-            target_tag: 3.6-alpine
+
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
@@ -53,15 +47,3 @@ jobs:
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - uses: loft-sh/setup-devspace@main
       - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
-      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
-        continue-on-error: true
-        uses: snyk/actions/docker@master
-        with:
-          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -10,7 +10,7 @@ on:
       - "install_tooling.sh"
 
 env:
-  IMAGE_PREFIX: loftsh
+  IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
 
 jobs:
   python:
@@ -20,7 +20,8 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - run: chmod +x install_tooling.sh && sudo ./install_tooling.sh
+      - name: Install DevSpace
+        uses: loft-sh/setup-devspace@main
       - run: |
           devspace build --var TAG=latest
           devspace build --var TAG=3.9-alpine

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   python:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -8,24 +8,59 @@ on:
       - "ruby/**"
       - ".github/workflows/ruby.yaml"
       - "install_tooling.sh"
+  workflow_call:
+    secrets:
+      IMAGE_PREFIX:
+        description: "registry.com/loftsh in registry.com/loftsh/language:TAG"
+        required: true
 
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
+  LANGUAGE: "ruby"
+  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+defaults:
+  run:
+    working-directory: ruby
 
 jobs:
   ruby:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tag: 3-alpine
+            target_tag: latest
+          - tag: 3-alpine
+            target_tag: 3-alpine
+          - tag: 3.1-alpine
+            target_tag: 3.1-alpine
+          - tag: 3.0-alpine
+            target_tag: 3.0-alpine
+          - tag: 2-alpine
+            target_tag: 2-alpine
+          - tag: 2.7-alpine
+            target_tag: 2.7-alpine
+          - tag: 2.6-alpine
+            target_tag: 2.6-alpine
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - name: Install DevSpace
-        uses: loft-sh/setup-devspace@main
-      - run: |
-          devspace build --var TAG=3.0.2 --var TARGET_TAG=latest
-          devspace build --var TAG=3.0-alpine --var TARGET_TAG=3.0-alpine
-          devspace build --var TAG=2.6-alpine --var TARGET_TAG=2.6-alpine
-          devspace build --var TAG=2.5-alpine --var TARGET_TAG=2.5-alpine
-        working-directory: ./ruby
+      - uses: loft-sh/setup-devspace@main
+      - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
+      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        with:
+          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
+      - name: Upload result to GitHub Code Scanning
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: snyk.sarif
+          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"
 

--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -17,7 +17,6 @@ on:
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
   LANGUAGE: "ruby"
-  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
 defaults:
   run:
@@ -38,12 +37,7 @@ jobs:
             target_tag: 3.1-alpine
           - tag: 3.0-alpine
             target_tag: 3.0-alpine
-          - tag: 2-alpine
-            target_tag: 2-alpine
-          - tag: 2.7-alpine
-            target_tag: 2.7-alpine
-          - tag: 2.6-alpine
-            target_tag: 2.6-alpine
+
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
@@ -51,16 +45,4 @@ jobs:
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - uses: loft-sh/setup-devspace@main
       - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
-      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
-        continue-on-error: true
-        uses: snyk/actions/docker@master
-        with:
-          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"
 

--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -10,7 +10,7 @@ on:
       - "install_tooling.sh"
 
 env:
-  IMAGE_PREFIX: loft${{ secrets.IMAGE_PREFIX }}sh
+  IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
 
 jobs:
   ruby:

--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -10,7 +10,7 @@ on:
       - "install_tooling.sh"
 
 env:
-  IMAGE_PREFIX: loftsh
+  IMAGE_PREFIX: loft${{ secrets.IMAGE_PREFIX }}sh
 
 jobs:
   ruby:
@@ -20,7 +20,8 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - run: chmod +x install_tooling.sh && sudo ./install_tooling.sh
+      - name: Install DevSpace
+        uses: loft-sh/setup-devspace@main
       - run: |
           devspace build --var TAG=3.0.2 --var TARGET_TAG=latest
           devspace build --var TAG=3.0-alpine --var TARGET_TAG=3.0-alpine

--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   ruby:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -63,22 +63,3 @@ jobs:
         with:
           sarif_file: snyk.sarif
           category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"
-
-
-
-
-
-      - uses: actions/checkout@v2
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
-      - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - name: Install DevSpace
-        uses: loft-sh/setup-devspace@main
-      - run: |
-          devspace build --var TAG=latest
-          devspace build --var TAG=15-alpine
-          devspace build --var TAG=14-alpine
-          devspace build --var TAG=12-alpine
-          devspace build --var TAG=10-alpine
-        working-directory: ./typescript
-

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -10,7 +10,7 @@ on:
       - "install_tooling.sh"
 
 env:
-  IMAGE_PREFIX: loftsh
+  IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
 
 jobs:
   typescript:
@@ -20,7 +20,8 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - run: chmod +x install_tooling.sh && sudo ./install_tooling.sh
+      - name: Install DevSpace
+        uses: loft-sh/setup-devspace@main
       - run: |
           devspace build --var TAG=latest
           devspace build --var TAG=15-alpine

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   typescript:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -17,7 +17,6 @@ on:
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
   LANGUAGE: "typescript"
-  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
 defaults:
   run:
@@ -36,14 +35,9 @@ jobs:
             target_tag: 17-alpine
           - tag: lts-alpine
             target_tag: lts-alpine
-          - tag: lts-alpine
-            target_tag: lts
           - tag: 16-alpine
             target_tag: 16-alpine
-          - tag: 14-alpine
-            target_tag: 14-alpine
-          - tag: 12-alpine
-            target_tag: 12-alpine
+
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
@@ -51,15 +45,3 @@ jobs:
       - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - uses: loft-sh/setup-devspace@main
       - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
-      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
-        continue-on-error: true
-        uses: snyk/actions/docker@master
-        with:
-          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
-          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
-      - name: Upload result to GitHub Code Scanning
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: snyk.sarif
-          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -8,14 +8,66 @@ on:
       - "typescript/**"
       - ".github/workflows/typescript.yaml"
       - "install_tooling.sh"
+  workflow_call:
+    secrets:
+      IMAGE_PREFIX:
+        description: "registry.com/loftsh in registry.com/loftsh/language:TAG"
+        required: true
 
 env:
   IMAGE_PREFIX: ${{ secrets.IMAGE_PREFIX }}
+  LANGUAGE: "typescript"
+  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+defaults:
+  run:
+    working-directory: typescript
 
 jobs:
   typescript:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tag: 17-alpine
+            target_tag: latest
+          - tag: 17-alpine
+            target_tag: 17-alpine
+          - tag: lts-alpine
+            target_tag: lts-alpine
+          - tag: lts-alpine
+            target_tag: lts
+          - tag: 16-alpine
+            target_tag: 16-alpine
+          - tag: 14-alpine
+            target_tag: 14-alpine
+          - tag: 12-alpine
+            target_tag: 12-alpine
     steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - uses: loft-sh/setup-devspace@main
+      - run: devspace build --var TAG=${{ matrix.tag }} --var TARGET_TAG=${{ matrix.target_tag }}
+      - name: Synk Docker scan for TAG=${{ matrix.target_tag }}
+        continue-on-error: true
+        uses: snyk/actions/docker@master
+        with:
+          image: ${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}
+          args: --file=go/Dockerfile --severity-threshold=high --exclude-base-image-vulns
+      - name: Upload result to GitHub Code Scanning
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: snyk.sarif
+          category: "${{ env.IMAGE_PREFIX }}/${{ env.LANGUAGE }}:${{ matrix.target_tag }}"
+
+
+
+
+
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .devspace/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# devtools-containers
+# Dev-Optimized Container Images For Cloud-Native Development
 
 [![Build Alpine](https://github.com/loft-sh/devtools-containers/actions/workflows/alpine.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/alpine.yaml)
 [![Build .NET](https://github.com/loft-sh/devtools-containers/actions/workflows/dotnet.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/dotnet.yaml)
@@ -11,7 +11,7 @@
 [![Build Ruby](https://github.com/loft-sh/devtools-containers/actions/workflows/ruby.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/ruby.yaml)
 [![Build TypeScript](https://github.com/loft-sh/devtools-containers/actions/workflows/typescript.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/typescript.yaml)
 
-You can pull images from the [loftsh repo](https://hub.docker.com/r/loftsh)
+You can pull images from the [Loft Labs repo](https://hub.docker.com/r/loftsh).
 
 ## Additional packages installed
 
@@ -25,121 +25,161 @@ You can pull images from the [loftsh repo](https://hub.docker.com/r/loftsh)
 - openssl
 - nodejs-lts/nodejs (Current LTS is v16.x.y)
 
-### For Alpine
+### For Alpine distribution
 
 - iputils
 - bind-tools
 
-### For Debian/Ubuntu
+### For Debian/Ubuntu distribution
 
 - inetutils-ping
 - dnsutils
 
-## Alpine
+## Architecture
 
-- edge
-- latest
-- 3.14
-- 3.13
-- 3.12
+Following architectures are supported on all images unless specified otherwise. The architecture support depends on the base images.
 
-## Go
+- linux/amd64
+- linux/arm64
+
+## [Alpine Images](https://hub.docker.com/r/loftsh/alpine/tags)
+
+Base repo: [Alpine](https://hub.docker.com/_/alpine).
 
 ### Tags
 
-- latest (based on 1.17-alpine)
-- 1.18-rc-alpine
-- 1.17-alpine
-- 1.16-alpine
+- [latest](https://hub.docker.com/r/loftsh/alpine/tags?name=latest) (Base image: [alpine:latest](https://hub.docker.com/_/alpine?tab=tags&name=latest))
+- [3.14](https://hub.docker.com/r/loftsh/alpine/tags?name=3.14) (Base image: [alpine:3.14](https://hub.docker.com/_/alpine?tab=tags&name=3.14))
+- [3.14](https://hub.docker.com/r/loftsh/alpine/tags?name=3.13) (Base image: [alpine:3.13](https://hub.docker.com/_/alpine?tab=tags&name=3.13))
+- [3.14](https://hub.docker.com/r/loftsh/alpine/tags?name=3.12) (Base image: [alpine:3.12](https://hub.docker.com/_/alpine?tab=tags&name=3.12))
+
+### Additional software/packages installed
+
+- none
+## [Go](https://hub.docker.com/r/loftsh/go/tags)
+
+Base repo: [Golang](https://hub.docker.com/_/golang).
+### Tags
+
+- [latest](https://hub.docker.com/r/loftsh/go/tags?name=latest) (Base image: [golang:latest](https://hub.docker.com/_/golang?tab=tags&name=latest))
+- [1.17-alpine](https://hub.docker.com/r/loftsh/go/tags?name=1.17-alpine) (Base image: [golang:1.17-alpine](https://hub.docker.com/_/golang?tab=tags&name=1.17-alpine))
+- [1.16-alpine](https://hub.docker.com/r/loftsh/go/tags?name=1.16-alpine) (Base image: [golang:1.16-alpine](https://hub.docker.com/_/golang?tab=tags&name=1.16-alpine))
 
 ### Additional software/packages installed
 
 - [Delve (@latest)](https://github.com/go-delve/delve)
 
-## .NET
+## [.NET](https://hub.docker.com/r/loftsh/dotnet/tags)
+
+Base repo: [dotnet](https://hub.docker.com/_/microsoft-dotnet-sdk).
 
 ### Tags
 
-- latest (based on mcr.microsoft.com/dotnet/sdk:6.0-alpine)
-- 6.0 (based on mcr.microsoft.com/dotnet/sdk:6.0-alpine)
-- 6.0-alpine
-- 5.0-bullseye-slim
-- 5.0 (based on mcr.microsoft.com/dotnet/sdk:5.0-bullseye-slim)
-- 3.1
+- [latest](https://hub.docker.com/r/loftsh/dotnet/tags?name=latest) (Base image: [mcr.microsoft.com/dotnet/sdk:6.0-alpine](https://hub.docker.com/_/microsoft-dotnet-sdk))
+- [6.0-alpine](https://hub.docker.com/r/loftsh/dotnet/tags?name=6.0-alpine) (Base image: [mcr.microsoft.com/dotnet/sdk:6.0-alpine](https://hub.docker.com/_/microsoft-dotnet-sdk))
+- [5.0-bullseye-slim](https://hub.docker.com/r/loftsh/dotnet/tags?name=5.0-bullseye-slim) (Base image: [mcr.microsoft.com/dotnet/sdk:5.0-bullseye-slim](https://hub.docker.com/_/microsoft-dotnet-sdk))
 
-## Gradle
+### Additional software/packages installed
 
-### Tags
+- none
 
-- latest (based on 7.3-jdk17-alpine)
-- 7.3-jdk17-alpine
-- 7.3-jdk11-alpine
-- 7-jdk17-alpine
-- 7-jdk11-alpine
-- 6-jdk17-alpine
-- 6-jdk11-alpine
+## [Gradle](https://hub.docker.com/r/loftsh/java-gradle/tags)
 
-## Maven
+Base repo: [gradle](https://hub.docker.com/_/gradle).
 
 ### Tags
 
-- latest (based on 3-openjdk-17-slim)
-- 3-openjdk-17-slim
-- 3-openjdk-11-slim
-- 3-openjdk-8-slim
-- 3-ibmjava-alpine
-- 3-ibmjava-8-alpine
+- [latest](https://hub.docker.com/r/loftsh/java-gradle/tags?name=latest) (Base image: [gradle:latest](https://hub.docker.com/_/gradle?tab=tags&name=latest))
+- [7-jdk17](https://hub.docker.com/r/loftsh/java-gradle/tags?name=7-jdk17) (Base image: [gradle:7-jdk17](https://hub.docker.com/_/gradle?tab=tags&name=7-jdk17))
+- [7-jdk11](https://hub.docker.com/r/loftsh/java-gradle/tags?name=7-jdk11) (Base image: [gradle:7-jdk11](https://hub.docker.com/_/gradle?tab=tags&name=7-jdk11))
+- [6-jdk17](https://hub.docker.com/r/loftsh/java-gradle/tags?name=6-jdk17) (Base image: [gradle:6-jdk17](https://hub.docker.com/_/gradle?tab=tags&name=6-jdk17))
+- [6-jdk11](https://hub.docker.com/r/loftsh/java-gradle/tags?name=6-jdk11) (Base image: [gradle:6-jdk11](https://hub.docker.com/_/gradle?tab=tags&name=6-jdk11))
 
-## JavaScript
+### Additional software/packages installed
 
-### Tags
+- none
 
-- latest (based on 17-alpine)
-- 17-alpine
-- lts-alpine
-- lts (based on lts-alpine)
-- 14-alpine
-- 12-alpine
+## [Maven](https://hub.docker.com/r/loftsh/java-maven/tags)
 
-
-## PHP
+Base repo: [maven](https://hub.docker.com/_/maven).
 
 ### Tags
 
-- latest (based on 8-apache-bullseye)
-- latest-apache (based on 8-apache-bullseye)
-- apache (based on 8-apache-bullseye)
-- 8.1-apache-bullseye
-- 8.0-apache-bullseye
-- 7-apache-bullseye
-- 5-apache
-- latest-fpm (based on 8-fpm)
-- fpm (based on 8-fpm)
-- 8-fpm
-- 7-fpm
+- [latest](https://hub.docker.com/r/loftsh/java-maven/tags?name=latest) (Base image: [maven:3-openjdk-17-slim](https://hub.docker.com/_/maven?tab=tags&name=3-openjdk-17-slim))
+- [3-openjdk-17-slim](https://hub.docker.com/r/loftsh/java-maven/tags?name=3-openjdk-17-slim) (Base image: [maven:3-openjdk-17-slim](https://hub.docker.com/_/maven?tab=tags&name=3-openjdk-17-slim))
+- [3-openjdk-11-slim](https://hub.docker.com/r/loftsh/java-maven/tags?name=3-openjdk-11-slim) (Base image: [maven:3-openjdk-11-slim](https://hub.docker.com/_/maven?tab=tags&name=3-openjdk-11-slim))
+- [3-openjdk-8-slim](https://hub.docker.com/r/loftsh/java-maven/tags?name=3-openjdk-8-slim) (Base image: [maven:3-openjdk-8-slim](https://hub.docker.com/_/maven?tab=tags&name=3-openjdk-8-slim))
 
-## Ruby
+### Additional software/packages installed
+
+- none
+## [JavaScript](https://hub.docker.com/r/loftsh/javascript/tags)
+
+Base repo: [node](https://hub.docker.com/_/node).
 
 ### Tags
 
-- latest (based on 3-alpine)
-- 3-alpine
-- 3.1-alpine
-- 3.0-alpine
-- 2-alpine
-- 2.7-alpine
-- 2.6-alpine
+- [latest](https://hub.docker.com/r/loftsh/javascript/tags?name=latest) (Base image: [node:17-alpine](https://hub.docker.com/_/node?tab=tags&name=17-alpine))
+- [17-alpine](https://hub.docker.com/r/loftsh/javascript/tags?name=17-alpine) (Base image: [node:17-alpine](https://hub.docker.com/_/node?tab=tags&name=17-alpine))
+- [lts-alpine](https://hub.docker.com/r/loftsh/javascript/tags?name=lts-alpine) (Base image: [node:lts-alpine](https://hub.docker.com/_/node?tab=tags&name=lts-alpine))
+- [16-alpine](https://hub.docker.com/r/loftsh/javascript/tags?name=16-alpine) (Base image: [node:16-alpine](https://hub.docker.com/_/node?tab=tags&name=16-alpine))
+
+## [PHP](https://hub.docker.com/r/loftsh/php/tags)
+
+Base repo: [php](https://hub.docker.com/_/php).
+### Tags
+
+- [latest](https://hub.docker.com/r/loftsh/php/tags?name=latest) (Base image: [php:8-apache-bullseye](https://hub.docker.com/_/php?tab=tags&name=8-apache-bullseye))
+- [latest-apache](https://hub.docker.com/r/loftsh/php/tags?name=latest-apache) (Base image: [php:8-apache-bullseye](https://hub.docker.com/_/php?tab=tags&name=8-apache-bullseye))
+- [8-apache-bullseye](https://hub.docker.com/r/loftsh/php/tags?name=8-apache-bullseye) (Base image: [php:8-apache-bullseye](https://hub.docker.com/_/php?tab=tags&name=8-apache-bullseye))
+- [8.1-apache-bullseye](https://hub.docker.com/r/loftsh/php/tags?name=8.1-apache-bullseye) (Base image: [php:8.1-apache-bullseye](https://hub.docker.com/_/php?tab=tags&name=8.1-apache-bullseye))
+- [8.0-apache-bullseye](https://hub.docker.com/r/loftsh/php/tags?name=8.0-apache-bullseye) (Base image: [php:8.0-apache-bullseye](https://hub.docker.com/_/php?tab=tags&name=8.0-apache-bullseye))
+- [7-apache-bullseye](https://hub.docker.com/r/loftsh/php/tags?name=7-apache-bullseye) (Base image: [php:7-apache-bullseye](https://hub.docker.com/_/php?tab=tags&name=7-apache-bullseye))
+- [latest-fpm](https://hub.docker.com/r/loftsh/php/tags?name=latest-fpm) (Base image: [php:8-fpm](https://hub.docker.com/_/php?tab=tags&name=8-fpm))
+- [8-fpm](https://hub.docker.com/r/loftsh/php/tags?name=8-fpm) (Base image: [php:8-fpm](https://hub.docker.com/_/php?tab=tags&name=8-fpm))
+- [7-fpm](https://hub.docker.com/r/loftsh/php/tags?name=7-fpm) (Base image: [php:7-fpm](https://hub.docker.com/_/php?tab=tags&name=7-fpm))
+
+### Additional software/packages installed
+
+- none
+
+## [Python](https://hub.docker.com/r/loftsh/python/tags)
+
+Base repo: [python](https://hub.docker.com/_/python).
+### Tags
+
+- [latest](https://hub.docker.com/r/loftsh/python/tags?name=latest) (Base image: [python:3-alpine](https://hub.docker.com/_/python?tab=tags&name=3-alpine))
+- [3-alpine](https://hub.docker.com/r/loftsh/python/tags?name=3-alpine) (Base image: [python:3-alpine](https://hub.docker.com/_/python?tab=tags&name=3-alpine))
+- [3.10-alpine](https://hub.docker.com/r/loftsh/python/tags?name=3.10-alpine) (Base image: [python:3.10-alpine](https://hub.docker.com/_/python?tab=tags&name=3.10-alpine))
+- [3.9-alpine](https://hub.docker.com/r/loftsh/python/tags?name=3.9-alpine) (Base image: [python:3.9-alpine](https://hub.docker.com/_/python?tab=tags&name=3.9-alpine))
+- [3.8-alpine](https://hub.docker.com/r/loftsh/python/tags?name=3.8-alpine) (Base image: [python:3.8-alpine](https://hub.docker.com/_/python?tab=tags&name=3.8-alpine))
+
+### Additional software/packages installed
+
+- none
+
+## [Ruby](https://hub.docker.com/r/loftsh/ruby/tags)
+
+Base repo: [ruby](https://hub.docker.com/_/ruby).
+### Tags
+
+- [latest](https://hub.docker.com/r/loftsh/ruby/tags?name=latest) (Base image: [ruby:3-alpine](https://hub.docker.com/_/ruby?tab=tags&name=3-alpine))
+- [3-alpine](https://hub.docker.com/r/loftsh/ruby/tags?name=3-alpine) (Base image: [ruby:3-alpine](https://hub.docker.com/_/ruby?tab=tags&name=3-alpine))
+- [3.1-alpine](https://hub.docker.com/r/loftsh/ruby/tags?name=3.1-alpine) (Base image: [ruby:3.1-alpine](https://hub.docker.com/_/ruby?tab=tags&name=3.1-alpine))
+- [3.0-alpine](https://hub.docker.com/r/loftsh/ruby/tags?name=3.0-alpine) (Base image: [ruby:3.0-alpine](https://hub.docker.com/_/ruby?tab=tags&name=3.0-alpine))
+
+### Additional software/packages installed
+
+- none
 
 ## TypeScript
 
 ### Tags
 
-- latest (based on 17-alpine)
-- 17-alpine
-- lts-alpine
-- lts (based on lts-alpine)
-- 14-alpine
-- 12-alpine
+- [latest](https://hub.docker.com/r/loftsh/typescript/tags?name=latest) (Base image: [node:17-alpine](https://hub.docker.com/_/node?tab=tags&name=17-alpine))
+- [17-alpine](https://hub.docker.com/r/loftsh/typescript/tags?name=17-alpine) (Base image: [node:17-alpine](https://hub.docker.com/_/node?tab=tags&name=17-alpine))
+- [lts-alpine](https://hub.docker.com/r/loftsh/typescript/tags?name=lts-alpine) (Base image: [node:lts-alpine](https://hub.docker.com/_/node?tab=tags&name=lts-alpine))
+- [16-alpine](https://hub.docker.com/r/loftsh/typescript/tags?name=16-alpine) (Base image: [node:16-alpine](https://hub.docker.com/_/node?tab=tags&name=16-alpine))
 
 ### Additional software/packages installed
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,3 @@
 [![Build TypeScript](https://github.com/loft-sh/devtools-containers/actions/workflows/typescript.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/typescript.yaml)
 
 # devtools-containers
-## TODOs
-
-- TODO: devspace.yaml update to install devspace-restart-helper script & bump devspace config version.
-- TODO: GH Actions update for latest image tags for all languages.
-- TODO: GH Actions update for agent OS to ubuntu-latest.
-- TODO: Remove installation and executing of install_tooling.sh on GH Actions agents, only DevSpace CLI is needed.
-- TODO: Add `TARGET_TAG` to all laguages and standardize to yy/xx:LATEST_VERSION-alpine to : latest
-- Create documentation for Docker Hub.
-- Create documentationn for GitHub.
-- Synk scan action in the GH action workflows: 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
-# devtools-containers
+[![Build Alpine](https://github.com/loft-sh/devtools-containers/actions/workflows/alpine.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/alpine.yaml)
+[![Build .NET](https://github.com/loft-sh/devtools-containers/actions/workflows/dotnet.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/dotnet.yaml)
+[![Build Go](https://github.com/loft-sh/devtools-containers/actions/workflows/go.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/go.yaml)
+[![Build Java (gradle)](https://github.com/loft-sh/devtools-containers/actions/workflows/java-gradle.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/java-gradle.yaml)
+[![Build Java (maven)](https://github.com/loft-sh/devtools-containers/actions/workflows/java-maven.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/java-maven.yaml)
+[![Build JavaScript](https://github.com/loft-sh/devtools-containers/actions/workflows/javascript.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/javascript.yaml)
+[![Build PHP](https://github.com/loft-sh/devtools-containers/actions/workflows/php.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/php.yaml)
+[![Build Python](https://github.com/loft-sh/devtools-containers/actions/workflows/python.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/python.yaml)
+[![Build Ruby](https://github.com/loft-sh/devtools-containers/actions/workflows/ruby.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/ruby.yaml)
+[![Build TypeScript](https://github.com/loft-sh/devtools-containers/actions/workflows/typescript.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/typescript.yaml)
 
-## .NET
-[![Build .NET](https://github.com/leventogut/devtools-containers/actions/workflows/dotnet.yaml/badge.svg)](https://github.com/leventogut/devtools-containers/actions/workflows/dotnet.yaml)
+# devtools-containers
 ## TODOs
 
 - TODO: devspace.yaml update to install devspace-restart-helper script & bump devspace config version.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # devtools-containers
+
+## TODOs
+
+- TODO: devspace.yaml update to install devspace-restart-helper script & bump devspace config version.
+- TODO: GH Actions update for latest image tags for all languages.
+- TODO: GH Actions update for agent OS to ubuntu-latest.
+- TODO: Remove installation and executing of install_tooling.sh on GH Actions agents, only DevSpace CLI is needed.
+- TODO: Add `TARGET_TAG` to all laguages and standardize to yy/xx:LATEST_VERSION-alpine to : latest
+- Create documentation for Docker Hub.
+- Create documentationn for GitHub.
+- Synk scan action in the GH action workflows: 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can pull images from the [loftsh repo](https://hub.docker.com/r/loftsh)
 
 ## Additional packages installed
 
-### For all languages
+### For all distributions
 
 - curl
 - vim
@@ -35,6 +35,14 @@ You can pull images from the [loftsh repo](https://hub.docker.com/r/loftsh)
 - inetutils-ping
 - dnsutils
 
+## Alpine
+
+- edge
+- latest
+- 3.14
+- 3.13
+- 3.12
+
 ## Go
 
 ### Tags
@@ -44,7 +52,7 @@ You can pull images from the [loftsh repo](https://hub.docker.com/r/loftsh)
 - 1.17-alpine
 - 1.16-alpine
 
-### Additional packages installed
+### Additional software/packages installed
 
 - [Delve (@latest)](https://github.com/go-delve/delve)
 
@@ -58,3 +66,82 @@ You can pull images from the [loftsh repo](https://hub.docker.com/r/loftsh)
 - 5.0-bullseye-slim
 - 5.0 (based on mcr.microsoft.com/dotnet/sdk:5.0-bullseye-slim)
 - 3.1
+
+## Gradle
+
+### Tags
+
+- latest (based on 7.3-jdk17-alpine)
+- 7.3-jdk17-alpine
+- 7.3-jdk11-alpine
+- 7-jdk17-alpine
+- 7-jdk11-alpine
+- 6-jdk17-alpine
+- 6-jdk11-alpine
+
+## Maven
+
+### Tags
+
+- latest (based on 3-openjdk-17-slim)
+- 3-openjdk-17-slim
+- 3-openjdk-11-slim
+- 3-openjdk-8-slim
+- 3-ibmjava-alpine
+- 3-ibmjava-8-alpine
+
+## JavaScript
+
+### Tags
+
+- latest (based on 17-alpine)
+- 17-alpine
+- lts-alpine
+- lts (based on lts-alpine)
+- 14-alpine
+- 12-alpine
+
+
+## PHP
+
+### Tags
+
+- latest (based on 8-apache-bullseye)
+- latest-apache (based on 8-apache-bullseye)
+- apache (based on 8-apache-bullseye)
+- 8.1-apache-bullseye
+- 8.0-apache-bullseye
+- 7-apache-bullseye
+- 5-apache
+- latest-fpm (based on 8-fpm)
+- fpm (based on 8-fpm)
+- 8-fpm
+- 7-fpm
+
+## Ruby
+
+### Tags
+
+- latest (based on 3-alpine)
+- 3-alpine
+- 3.1-alpine
+- 3.0-alpine
+- 2-alpine
+- 2.7-alpine
+- 2.6-alpine
+
+## TypeScript
+
+### Tags
+
+- latest (based on 17-alpine)
+- 17-alpine
+- lts-alpine
+- lts (based on lts-alpine)
+- 14-alpine
+- 12-alpine
+
+### Additional software/packages installed
+
+- typescript
+- tsc-watch

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# devtools-containers
+
 [![Build Alpine](https://github.com/loft-sh/devtools-containers/actions/workflows/alpine.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/alpine.yaml)
 [![Build .NET](https://github.com/loft-sh/devtools-containers/actions/workflows/dotnet.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/dotnet.yaml)
 [![Build Go](https://github.com/loft-sh/devtools-containers/actions/workflows/go.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/go.yaml)
@@ -9,4 +11,50 @@
 [![Build Ruby](https://github.com/loft-sh/devtools-containers/actions/workflows/ruby.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/ruby.yaml)
 [![Build TypeScript](https://github.com/loft-sh/devtools-containers/actions/workflows/typescript.yaml/badge.svg)](https://github.com/loft-sh/devtools-containers/actions/workflows/typescript.yaml)
 
-# devtools-containers
+You can pull images from the [loftsh repo](https://hub.docker.com/r/loftsh)
+
+## Additional packages installed
+
+### For all languages
+
+- curl
+- vim
+- wget
+- bash
+- git
+- openssl
+- nodejs-lts/nodejs (Current LTS is v16.x.y)
+
+### For Alpine
+
+- iputils
+- bind-tools
+
+### For Debian/Ubuntu
+
+- inetutils-ping
+- dnsutils
+
+## Go
+
+### Tags
+
+- latest (based on 1.17-alpine)
+- 1.18-rc-alpine
+- 1.17-alpine
+- 1.16-alpine
+
+### Additional packages installed
+
+- [Delve (@latest)](https://github.com/go-delve/delve)
+
+## .NET
+
+### Tags
+
+- latest (based on mcr.microsoft.com/dotnet/sdk:6.0-alpine)
+- 6.0 (based on mcr.microsoft.com/dotnet/sdk:6.0-alpine)
+- 6.0-alpine
+- 5.0-bullseye-slim
+- 5.0 (based on mcr.microsoft.com/dotnet/sdk:5.0-bullseye-slim)
+- 3.1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # devtools-containers
 
+## .NET
+[![Build .NET](https://github.com/leventogut/devtools-containers/actions/workflows/dotnet.yaml/badge.svg)](https://github.com/leventogut/devtools-containers/actions/workflows/dotnet.yaml)
 ## TODOs
 
 - TODO: devspace.yaml update to install devspace-restart-helper script & bump devspace config version.

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,7 +1,5 @@
 ARG  TAG=3
 FROM alpine:${TAG}
 
-RUN apk update && apk add bash
-
 # Create project directory (workdir)
 WORKDIR /app

--- a/alpine/devspace.yaml
+++ b/alpine/devspace.yaml
@@ -2,7 +2,7 @@ version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/alpine
-    tags: ["${TAG}"]
+    tags: ["${TARGET_TAG}"]
     context: ../
     appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:

--- a/alpine/devspace.yaml
+++ b/alpine/devspace.yaml
@@ -1,10 +1,10 @@
-version: v1beta9
+version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/alpine
     tags: ["${TAG}"]
     context: ../
-    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh"]
+    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:
       buildKit:
         skipPush: false

--- a/devspace-restart-helper
+++ b/devspace-restart-helper
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# A process wrapper script to simulate a container restart. This file was injected with devspace during the build process
+#
+set -e
+pid=""
+trap quit TERM INT
+quit() {
+  if [ -n "$pid" ]; then
+    kill $pid
+  fi
+}
+while true; do
+  setsid "$@" &
+  pid=$!
+  echo "$pid" > /.devspace/devspace-pid
+  set +e
+  wait $pid
+  exit_code=$?
+  if [ -f /.devspace/devspace-pid ]; then
+    rm -f /.devspace/devspace-pid
+    printf "\nContainer exited with $exit_code. Will restart in 7 seconds...\n"
+    sleep 7
+  fi
+  set -e
+  printf "\n\n############### Restart container ###############\n\n"
+done
+

--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -1,4 +1,4 @@
-ARG  TAG=5.0
+ARG  TAG=6.0-alpine
 FROM mcr.microsoft.com/dotnet/sdk:${TAG}
 
 # Create project directory (workdir)

--- a/dotnet/devspace.yaml
+++ b/dotnet/devspace.yaml
@@ -1,10 +1,10 @@
-version: v1beta9
+version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/dotnet
     tags: ["${TAG}"]
     context: ../
-    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh"]
+    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:
       buildKit:
         skipPush: false

--- a/dotnet/devspace.yaml
+++ b/dotnet/devspace.yaml
@@ -2,7 +2,7 @@ version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/dotnet
-    tags: ["${TAG}"]
+    tags: ["${TARGET_TAG}"]
     context: ../
     appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:

--- a/go/devspace.yaml
+++ b/go/devspace.yaml
@@ -1,10 +1,10 @@
-version: v1beta9
+version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/go
     tags: ["${TAG}"]
     context: ../
-    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh"]
+    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:
       buildKit:
         skipPush: false

--- a/go/devspace.yaml
+++ b/go/devspace.yaml
@@ -2,7 +2,7 @@ version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/go
-    tags: ["${TAG}"]
+    tags: ["${TARGET_TAG}"]
     context: ../
     appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:

--- a/go/devspace.yaml
+++ b/go/devspace.yaml
@@ -12,3 +12,5 @@ images:
         options:
           buildArgs:
             TAG: ${TAG}
+
+

--- a/install_tooling.sh
+++ b/install_tooling.sh
@@ -2,7 +2,7 @@
 
 DEVSPACE_VERSION="latest"
 
-apk add --no-cache curl vim wget bash iputils bind-tools git nodejs npm openssl || (apt-get update && apt -y install curl vim wget bash inetutils-ping dnsutils git openssl && curl -sL https://deb.nodesource.com/setup_14.x -o nodesource_setup.sh && bash nodesource_setup.sh && apt install nodejs)
+apk add --no-cache curl vim wget bash iputils bind-tools git nodejs-lts npm openssl || (apt-get update && apt-get -y install curl vim wget bash inetutils-ping dnsutils git openssl && curl -sL https://deb.nodesource.com/setup_lts.x -o nodesource_setup.sh && bash nodesource_setup.sh && apt-get install nodejs)
 
 npm install -g yarn
 
@@ -14,7 +14,8 @@ fi
 
 curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$ARCH_SHORT/kubectl"
 chmod +x kubectl
-install kubectl /usr/local/bin;
+install -p kubectl /usr/local/bin;
+rm kubectl
 
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 chmod +x get_helm.sh
@@ -23,12 +24,14 @@ rm get_helm.sh
 
 curl -s -L "https://github.com/loft-sh/devspace/releases/$DEVSPACE_VERSION" | sed -nE 's!.*"([^"]*devspace-linux-'$ARCH_SHORT')".*!https://github.com\1!p' | xargs -n 1 curl -L -o devspace
 chmod +x devspace
-install devspace /usr/local/bin;
+install -p devspace /usr/local/bin;
+rm devspace
 
 if [ "$ARCH" = "x86_64" ]; then
     devspace add plugin https://github.com/loft-sh/loft-devspace-plugin
 
     curl -s -L "https://github.com/loft-sh/loft/releases/latest" | sed -nE 's!.*"([^"]*loft-linux-'$ARCH_SHORT')".*!https://github.com\1!p' | xargs -n 1 curl -L -o loft
     chmod +x loft
-    install loft /usr/local/bin;
+    install -p loft /usr/local/bin;
+    rm loft
 fi

--- a/java-gradle/Dockerfile
+++ b/java-gradle/Dockerfile
@@ -1,4 +1,4 @@
-ARG  TAG=7.0-jdk11
+ARG  TAG=7-jdk17-alpine
 FROM gradle:${TAG}
 
 # Create project directory (workdir)

--- a/java-gradle/Dockerfile
+++ b/java-gradle/Dockerfile
@@ -1,4 +1,4 @@
-ARG  TAG=7-jdk17-alpine
+ARG  TAG=7-jdk17
 FROM gradle:${TAG}
 
 # Create project directory (workdir)

--- a/java-gradle/devspace.yaml
+++ b/java-gradle/devspace.yaml
@@ -2,7 +2,7 @@ version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/java-gradle
-    tags: ["${TAG}"]
+    tags: ["${TARGET_TAG}"]
     context: ../
     appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:

--- a/java-gradle/devspace.yaml
+++ b/java-gradle/devspace.yaml
@@ -1,10 +1,10 @@
-version: v1beta9
+version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/java-gradle
     tags: ["${TAG}"]
     context: ../
-    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh"]
+    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:
       buildKit:
         skipPush: false

--- a/java-maven/Dockerfile
+++ b/java-maven/Dockerfile
@@ -1,4 +1,4 @@
-ARG  TAG=3-jdk-11
+ARG  TAG=3-openjdk-17
 FROM maven:${TAG}
 
 # Create project directory (workdir)

--- a/java-maven/devspace.yaml
+++ b/java-maven/devspace.yaml
@@ -8,7 +8,7 @@ images:
     build:
       buildKit:
         skipPush: false
-        args: ["--platform", "linux/amd64"]
+        args: ["--platform", "linux/amd64,linux/arm64"]
         options:
           buildArgs:
             TAG: ${TAG}

--- a/java-maven/devspace.yaml
+++ b/java-maven/devspace.yaml
@@ -1,10 +1,10 @@
-version: v1beta9
+version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/java-maven
     tags: ["${TARGET_TAG}"]
     context: ../
-    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh"]
+    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:
       buildKit:
         skipPush: false

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -1,4 +1,4 @@
-ARG  TAG=15-alpine
+ARG  TAG=17-alpine
 FROM node:${TAG}
 
 # Set working directory

--- a/javascript/devspace.yaml
+++ b/javascript/devspace.yaml
@@ -2,7 +2,7 @@ version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/javascript
-    tags: ["${TAG}"]
+    tags: ["${TARGET_TAG}"]
     context: ../
     appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:

--- a/javascript/devspace.yaml
+++ b/javascript/devspace.yaml
@@ -1,10 +1,10 @@
-version: v1beta9
+version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/javascript
     tags: ["${TAG}"]
     context: ../
-    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh"]
+    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:
       buildKit:
         skipPush: false

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,4 +1,4 @@
-ARG  TAG=7.4.4-apache
+ARG  TAG=8-apache-bullseye
 FROM php:${TAG}
 ARG  TAG
 

--- a/php/devspace.yaml
+++ b/php/devspace.yaml
@@ -1,10 +1,10 @@
-version: v1beta9
+version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/php
     tags: ["${TARGET_TAG}"]
     context: ../
-    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh"]
+    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:
       buildKit:
         skipPush: false

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,4 @@
-ARG  TAG=3.8-slim-buster
+ARG  TAG=3-alpine
 FROM python:${TAG}
 
 # Create project directory (workdir)

--- a/python/devspace.yaml
+++ b/python/devspace.yaml
@@ -1,10 +1,10 @@
-version: v1beta9
+version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/python
     tags: ["${TAG}"]
     context: ../
-    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh"]
+    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:
       buildKit:
         skipPush: false

--- a/python/devspace.yaml
+++ b/python/devspace.yaml
@@ -2,7 +2,7 @@ version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/python
-    tags: ["${TAG}"]
+    tags: ["${TARGET_TAG}"]
     context: ../
     appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-ARG  TAG=2.7-alpine
+ARG  TAG=3-alpine
 FROM ruby:${TAG}
 
 # Create project directory (workdir)

--- a/ruby/devspace.yaml
+++ b/ruby/devspace.yaml
@@ -1,10 +1,10 @@
-version: v1beta9
+version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/ruby
     tags: ["${TARGET_TAG}"]
     context: ../
-    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh"]
+    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:
       buildKit:
         skipPush: false

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -1,4 +1,4 @@
-ARG  TAG=15-alpine
+ARG  TAG=17-alpine
 FROM node:${TAG}
 
 # Set working directory

--- a/typescript/devspace.yaml
+++ b/typescript/devspace.yaml
@@ -1,10 +1,10 @@
-version: v1beta9
+version: v1beta11
 images:
   app:
     image: ${IMAGE_PREFIX}/typescript
     tags: ["${TAG}"]
     context: ../
-    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh"]
+    appendDockerfileInstructions: ["ADD install_tooling.sh .", "RUN chmod +x install_tooling.sh && ./install_tooling.sh && rm install_tooling.sh","RUN mkdir /.devspace","ADD ./devspace-restart-helper /.devspace/","RUN chmod +x /.devspace/devspace-restart-helper"]
     build:
       buildKit:
         skipPush: false


### PR DESCRIPTION
fixes #5 

## New Requirements:
The following secrets are must be configured:
new secret: ${{ secrets.IMAGE_PREFIX }} loftsh # This is done for easing contributions, i.e. forks
new secret: ${{ secrets.SNYK_TOKEN }} # need to register on Snyk

- update all image versions from upstream
- install devspace-restart-helper
- enable custom tagging on all (TARGET_TAG)
- GH Actions flow change
- GH Actions Snyk security scanning (configured to ignore upstream vulnerabilities)
- remove install_tooling.sh from the builder (only devspace is needed on the builder)
- add loft-sh/setup-devspace@main to builder
- Change builder image from ubuntu-18.04 to ubuntu-latest
- readme.md update for latest available tags

Newly built images can be found [here](https://hub.docker.com/u/leventogut) for testing.
