### PR TITLE
Add dotnet 7 image

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -26,6 +26,8 @@ jobs:
       matrix:
         include:
           - tag: 7.0-alpine
+          - tag: 6.0-alpine
+          - tag: 5.0-alpine
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - tag: 6.0-alpine
+          - tag: 7.0-alpine
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -28,6 +28,7 @@ jobs:
           - tag: 7.0-alpine
           - tag: 6.0-alpine
           - tag: 5.0-alpine
+          - tag: 3.1-alpine
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Base repository: [dotnet](https://hub.docker.com/_/microsoft-dotnet-sdk)
 
 - [7.0-alpine](https://hub.docker.com/r/loftsh/dotnet/tags?name=latest) (Base image: [mcr.microsoft.com/dotnet/sdk:7.0-alpine](https://hub.docker.com/_/microsoft-dotnet-sdk))
 - [6.0-alpine](https://hub.docker.com/r/loftsh/dotnet/tags?name=6.0-alpine) (Base image: [mcr.microsoft.com/dotnet/sdk:6.0-alpine](https://hub.docker.com/_/microsoft-dotnet-sdk))
-- [5.0-bullseye-slim](https://hub.docker.com/r/loftsh/dotnet/tags?name=5.0-bullseye-slim) (Base image: [mcr.microsoft.com/dotnet/sdk:5.0-bullseye-slim](https://hub.docker.com/_/microsoft-dotnet-sdk))
+- [5.0-alpine](https://hub.docker.com/r/loftsh/dotnet/tags?name=6.0-alpine) (Base image: [mcr.microsoft.com/dotnet/sdk:5.0-alpine](https://hub.docker.com/_/microsoft-dotnet-sdk))
+- [3.1-alpine](https://hub.docker.com/r/loftsh/dotnet/tags?name=6.0-alpine) (Base image: [mcr.microsoft.com/dotnet/sdk:3.1-alpine](https://hub.docker.com/_/microsoft-dotnet-sdk))
 
 ## [Gradle](https://hub.docker.com/r/loftsh/java-gradle/tags)
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Base repository: [dotnet](https://hub.docker.com/_/microsoft-dotnet-sdk)
 
 ### Tags
 
-- [latest](https://hub.docker.com/r/loftsh/dotnet/tags?name=latest) (Base image: [mcr.microsoft.com/dotnet/sdk:6.0-alpine](https://hub.docker.com/_/microsoft-dotnet-sdk))
+- [7.0-alpine](https://hub.docker.com/r/loftsh/dotnet/tags?name=latest) (Base image: [mcr.microsoft.com/dotnet/sdk:7.0-alpine](https://hub.docker.com/_/microsoft-dotnet-sdk))
 - [6.0-alpine](https://hub.docker.com/r/loftsh/dotnet/tags?name=6.0-alpine) (Base image: [mcr.microsoft.com/dotnet/sdk:6.0-alpine](https://hub.docker.com/_/microsoft-dotnet-sdk))
 - [5.0-bullseye-slim](https://hub.docker.com/r/loftsh/dotnet/tags?name=5.0-bullseye-slim) (Base image: [mcr.microsoft.com/dotnet/sdk:5.0-bullseye-slim](https://hub.docker.com/_/microsoft-dotnet-sdk))
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Base repository: [dotnet](https://hub.docker.com/_/microsoft-dotnet-sdk)
 
 - [7.0-alpine](https://hub.docker.com/r/loftsh/dotnet/tags?name=latest) (Base image: [mcr.microsoft.com/dotnet/sdk:7.0-alpine](https://hub.docker.com/_/microsoft-dotnet-sdk))
 - [6.0-alpine](https://hub.docker.com/r/loftsh/dotnet/tags?name=6.0-alpine) (Base image: [mcr.microsoft.com/dotnet/sdk:6.0-alpine](https://hub.docker.com/_/microsoft-dotnet-sdk))
-- [5.0-alpine](https://hub.docker.com/r/loftsh/dotnet/tags?name=6.0-alpine) (Base image: [mcr.microsoft.com/dotnet/sdk:5.0-alpine](https://hub.docker.com/_/microsoft-dotnet-sdk))
-- [3.1-alpine](https://hub.docker.com/r/loftsh/dotnet/tags?name=6.0-alpine) (Base image: [mcr.microsoft.com/dotnet/sdk:3.1-alpine](https://hub.docker.com/_/microsoft-dotnet-sdk))
+- [5.0-alpine](https://hub.docker.com/r/loftsh/dotnet/tags?name=5.0-alpine) (Base image: [mcr.microsoft.com/dotnet/sdk:5.0-alpine](https://hub.docker.com/_/microsoft-dotnet-sdk))
+- [3.1-alpine](https://hub.docker.com/r/loftsh/dotnet/tags?name=3.1-alpine) (Base image: [mcr.microsoft.com/dotnet/sdk:3.1-alpine](https://hub.docker.com/_/microsoft-dotnet-sdk))
 
 ## [Gradle](https://hub.docker.com/r/loftsh/java-gradle/tags)
 

--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -1,4 +1,4 @@
-ARG  TAG=6.0-alpine
+ARG  TAG=7.0-alpine
 FROM mcr.microsoft.com/dotnet/sdk:${TAG}
 
 # Create project directory (workdir)


### PR DESCRIPTION
Adding a dotnet 7 image would be super helpful to me and I'm sure others that have looked at #11. I'm not sure what the contributing guidelines are but hopefully, this is enough to get the ball rolling. Please do let me know if this doesn't meet the requirements as I am unclear on what exactly loft-sh/setup-devspace or other github actions might be doing to add everything to the image.