### PR TITLE
Added dotnet 8 image

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -25,6 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - tag: 8.0-alpine
           - tag: 7.0-alpine
           - tag: 6.0-alpine
           - tag: 3.1-alpine


### PR DESCRIPTION
Fixes #26
ENG-2538

Image built ok locally, and was able confirm the version:
```sh
2a82800436ff:/app# dotnet --version
8.0.100
```