### PR TITLE
Update dotnet Dockerfile

### DIFF
--- a/dotnet/Dockerfile
+++ b/dotnet/Dockerfile
@@ -1,4 +1,4 @@
-ARG  TAG=7.0-alpine
+ARG  TAG=8.0-alpine
 FROM mcr.microsoft.com/dotnet/sdk:${TAG}
 
 # Create project directory (workdir)


### PR DESCRIPTION
dotnet8 version of devspace-containers is actually using dotnet/sdk:7.0-alpine base image in current `devspace-containers/dotnet:8.0-alpine` release.