### PR TITLE
feat: gradle upgrade to version 8

### DIFF
--- a/.github/workflows/java-gradle.yaml
+++ b/.github/workflows/java-gradle.yaml
@@ -25,12 +25,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - tag: 7-jdk17-slim
-          - tag: 7-jdk11-slim
-          - tag: 7-jdk8-slim
-          # - tag: 6-jdk17-slim
-          # - tag: 6-jdk11-slim
-          # - tag: 6-jdk8-slim
+         - tag: 8-jdk17-slim
+         - tag: 8-jdk11-slim
+         - tag: 8-jdk8-slim
+         # - tag: 7-jdk17-slim
+         # - tag: 7-jdk11-slim
+         # - tag: 7-jdk8-slim
+         # - tag: 6-jdk17-slim
+         # - tag: 6-jdk11-slim
+         # - tag: 6-jdk8-slim
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ Base repository: [gradle](https://hub.docker.com/_/gradle)
 
 ### Tags
 
-- [8-jdk17-slim](https://github.com/d-lopes/devspace-containers/pkgs/container/devspace-containers%2Fjava-gradle/65243610?tag=8-jdk17-slim) (Base image: [gradle:8-jdk17-slim](https://hub.docker.com/_/gradle?tab=tags&name=8-jdk17-slim))
 - [7-jdk17-slim](https://github.com/loft-sh/devspace-containers/pkgs/container/devspace-containers%2Fjava-gradle/65243610?tag=7-jdk17-slim) (Base image: [gradle:7-jdk17-slim](https://hub.docker.com/_/gradle?tab=tags&name=7-jdk17-slim))
 - [7-jdk11-slim](https://github.com/loft-sh/devspace-containers/pkgs/container/devspace-containers%2Fjava-gradle/65248914?tag=7-jdk11-slim) (Base image: [gradle:7-jdk11-slim](https://hub.docker.com/_/gradle?tab=tags&name=7-jdk11-slim))
 - [7-jdk8-slim](https://github.com/loft-sh/devspace-containers/pkgs/container/devspace-containers%2Fjava-gradle/65243515?tag=7-jdk8-slim) (Base image: [gradle:7-jdk8-slim](https://hub.docker.com/_/gradle?tab=tags&name=7-jdk8-slim))

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Base repository: [gradle](https://hub.docker.com/_/gradle)
 
 ### Tags
 
+- [8-jdk17-slim](https://github.com/d-lopes/devspace-containers/pkgs/container/devspace-containers%2Fjava-gradle/65243610?tag=8-jdk17-slim) (Base image: [gradle:8-jdk17-slim](https://hub.docker.com/_/gradle?tab=tags&name=8-jdk17-slim))
 - [7-jdk17-slim](https://github.com/loft-sh/devspace-containers/pkgs/container/devspace-containers%2Fjava-gradle/65243610?tag=7-jdk17-slim) (Base image: [gradle:7-jdk17-slim](https://hub.docker.com/_/gradle?tab=tags&name=7-jdk17-slim))
 - [7-jdk11-slim](https://github.com/loft-sh/devspace-containers/pkgs/container/devspace-containers%2Fjava-gradle/65248914?tag=7-jdk11-slim) (Base image: [gradle:7-jdk11-slim](https://hub.docker.com/_/gradle?tab=tags&name=7-jdk11-slim))
 - [7-jdk8-slim](https://github.com/loft-sh/devspace-containers/pkgs/container/devspace-containers%2Fjava-gradle/65243515?tag=7-jdk8-slim) (Base image: [gradle:7-jdk8-slim](https://hub.docker.com/_/gradle?tab=tags&name=7-jdk8-slim))

--- a/java-gradle/Dockerfile
+++ b/java-gradle/Dockerfile
@@ -1,4 +1,4 @@
-ARG  TAG=7-jdk17-slim
+ARG  TAG=8-jdk17-slim
 ARG  JDK_VERSION=17
 FROM maven:3-openjdk-${JDK_VERSION}-slim
 
@@ -37,8 +37,8 @@ RUN set -o errexit -o nounset \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 7.4.1
-ARG GRADLE_DOWNLOAD_SHA256=e5444a57cda4a95f90b0c9446a9e1b47d3d7f69057765bfb54bd4f482542d548
+ENV GRADLE_VERSION 8.8
+ARG GRADLE_DOWNLOAD_SHA256=a4b4158601f8636cdeeab09bd76afb640030bb5b144aafe261a5e8af027dc612
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \
     && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \


### PR DESCRIPTION
**Problem:**

We are developing a Java project using JDK 17 and Gradle 8.8. However, every time we use the existing docker image ghcr.io/loft-sh/devspace-containers/java-gradle:7-jdk11-slim, we have to reinstall Gradle 8.8 using the ./gradlew command in every devspace.

**Solution:**

Upgrade gradle version resulting in a JAVA container image for gradle 8.8 and JDK 17 and publish new docker image version
